### PR TITLE
Migrate from `rules_bzlformat`, `rules_updatesrc`, and `bazel_shlib` to `bazel-starlib`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,12 +4,12 @@ load(
     "integration_test_utils",
 )
 load(
-    "@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl",
+    "@cgrindel_bazel_starlib//bzlformat:defs.bzl",
     "bzlformat_missing_pkgs",
     "bzlformat_pkg",
 )
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
 )
 

--- a/README.md
+++ b/README.md
@@ -42,21 +42,13 @@ load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", 
 
 bazel_integration_test_rules_dependencies()
 
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
-
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
 
-load("@cgrindel_bazel_shlib//:deps.bzl", "shlib_rules_dependencies")
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
-shlib_rules_dependencies()
+bazel_skylib_workspace()
 ```
 
 ### 2. Create a `bazel_versions.bzl` in the root of your repository
@@ -225,8 +217,7 @@ local_repository(
 ```
 
 This section explains how to use `rules_bazel_integration_test` in this situation. To review working
-examples, check out [rules_updatesrc](https://github.com/cgrindel/rules_updatesrc),
-[rules_bzlformat](https://github.com/cgrindel/rules_bzlformat), and
+examples, check out [bazel-starlib](https://github.com/cgrindel/bazel-starlib) and
 [rules_spm](https://github.com/cgrindel/rules_spm).
 
 ### 1. Declare a `filegroup` to represent the parent workspace files

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,35 +4,21 @@ load("//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependen
 
 bazel_integration_test_rules_dependencies()
 
+load("@cgrindel_bazel_starlib//deps.bzl", "bazel_starlib_dependencies")
+
+bazel_starlib_dependencies()
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
 # MARK: - Documentation
 
-load("@cgrindel_bazel_doc//bazeldoc:deps.bzl", "bazeldoc_dependencies")
-
-bazeldoc_dependencies()
-
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
 
-# MARK: - Update Source
-
-load("@cgrindel_rules_updatesrc//updatesrc:deps.bzl", "updatesrc_rules_dependencies")
-
-updatesrc_rules_dependencies()
-
-# MARK: - rules_bzlformat
-
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
-load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
-
-bazel_starlib_dependencies()
+# MARK: - Buildifier Deps
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
@@ -47,12 +33,6 @@ gazelle_dependencies()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-# MARK: - bazel_shlib
-
-load("@cgrindel_bazel_shlib//:deps.bzl", "shlib_rules_dependencies")
-
-shlib_rules_dependencies()
 
 # MARK: - Integration Tests
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,7 @@ load("//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependen
 
 bazel_integration_test_rules_dependencies()
 
-load("@cgrindel_bazel_starlib//deps.bzl", "bazel_starlib_dependencies")
+load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
 

--- a/bazel_integration_test/BUILD.bazel
+++ b/bazel_integration_test/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/bazel_integration_test/deps.bzl
+++ b/bazel_integration_test/deps.bzl
@@ -14,30 +14,6 @@ def bazel_integration_test_rules_dependencies():
 
     maybe(
         http_archive,
-        name = "cgrindel_rules_updatesrc",
-        sha256 = "18eb6620ac4684c2bc722b8fe447dfaba76f73d73e2dfcaf837f542379ed9bc3",
-        strip_prefix = "rules_updatesrc-0.1.0",
-        urls = ["https://github.com/cgrindel/rules_updatesrc/archive/v0.1.0.tar.gz"],
-    )
-
-    maybe(
-        http_archive,
-        name = "cgrindel_rules_bzlformat",
-        sha256 = "44b09ad9c5395760065820676ba6e65efec08ae02c1ce7e2d39d42c5b1e7aec8",
-        strip_prefix = "rules_bzlformat-0.2.1",
-        urls = ["https://github.com/cgrindel/rules_bzlformat/archive/v0.2.1.tar.gz"],
-    )
-
-    maybe(
-        http_archive,
-        name = "cgrindel_bazel_doc",
-        sha256 = "3ccc6d205a7f834c5e89adcb4bc5091a9a07a69376107807eb9aea731ce92854",
-        strip_prefix = "bazel-doc-0.1.2",
-        urls = ["https://github.com/cgrindel/bazel-doc/archive/v0.1.2.tar.gz"],
-    )
-
-    maybe(
-        http_archive,
         name = "build_bazel_integration_testing",
         url = "https://github.com/bazelbuild/bazel-integration-testing/archive/3a6136e8f6287b04043217d94d97ba17edcb7feb.zip",
         type = "zip",
@@ -46,9 +22,7 @@ def bazel_integration_test_rules_dependencies():
     )
 
     maybe(
-        http_archive,
-        name = "cgrindel_bazel_shlib",
-        sha256 = "39c250852fb455e5de18f836c0c339075d6e52ea5ec52a76d62ef9e2eed56337",
-        strip_prefix = "bazel_shlib-0.2.1",
-        urls = ["https://github.com/cgrindel/bazel_shlib/archive/v0.2.1.tar.gz"],
+        native.local_repository,
+        name = "cgrindel_bazel_starlib",
+        path = "../bazel-starlib",
     )

--- a/bazel_integration_test/deps.bzl
+++ b/bazel_integration_test/deps.bzl
@@ -22,7 +22,11 @@ def bazel_integration_test_rules_dependencies():
     )
 
     maybe(
-        native.local_repository,
+        http_archive,
         name = "cgrindel_bazel_starlib",
-        path = "/Users/chuck/code/cgrindel/bazel-starlib",
+        sha256 = "238c05abf31447b93bd15b616c7413c4c719ee7b5e81c1489ca20f02ce628489",
+        strip_prefix = "bazel-starlib-0.2.0",
+        urls = [
+            "http://github.com/cgrindel/bazel-starlib/archive/v0.2.0.tar.gz",
+        ],
     )

--- a/bazel_integration_test/deps.bzl
+++ b/bazel_integration_test/deps.bzl
@@ -24,5 +24,5 @@ def bazel_integration_test_rules_dependencies():
     maybe(
         native.local_repository,
         name = "cgrindel_bazel_starlib",
-        path = "../bazel-starlib",
+        path = "/Users/chuck/code/cgrindel/bazel-starlib",
     )

--- a/bazel_integration_test/internal/BUILD.bazel
+++ b/bazel_integration_test/internal/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//bazel_integration_test:__subpackages__"])
 
@@ -29,7 +29,7 @@ bzl_library(
     srcs = ["default_test_runner.bzl"],
     deps = [
         ":integration_test_utils",
-        "@cgrindel_bazel_shlib//rules:execute_binary",
+        "@cgrindel_bazel_starlib//shlib/rules:execute_binary",
     ],
 )
 

--- a/bazel_integration_test/internal/bazel_integration_test.bzl
+++ b/bazel_integration_test/internal/bazel_integration_test.bzl
@@ -112,7 +112,7 @@ def bazel_integration_test(
         ],
         deps = [
             "@bazel_tools//tools/bash/runfiles",
-            "@cgrindel_bazel_shlib//lib:messages",
+            "@cgrindel_bazel_starlib//shlib/lib:messages",
         ],
         timeout = timeout,
         env = select({

--- a/bazel_integration_test/internal/default_test_runner.bzl
+++ b/bazel_integration_test/internal/default_test_runner.bzl
@@ -38,5 +38,5 @@ def default_test_runner(
     execute_binary(
         name = name,
         binary = binary_name,
-        args = args,
+        arguments = args,
     )

--- a/bazel_integration_test/internal/default_test_runner.bzl
+++ b/bazel_integration_test/internal/default_test_runner.bzl
@@ -1,4 +1,4 @@
-load("@cgrindel_bazel_shlib//rules:execute_binary.bzl", "execute_binary")
+load("@cgrindel_bazel_starlib//shlib/rules:execute_binary.bzl", "execute_binary")
 load(":integration_test_utils.bzl", "integration_test_utils")
 
 def default_test_runner(
@@ -28,7 +28,7 @@ def default_test_runner(
         ],
         deps = [
             "@bazel_tools//tools/bash/runfiles",
-            "@cgrindel_bazel_shlib//lib:messages",
+            "@cgrindel_bazel_starlib//shlib/lib:messages",
         ],
         args = args,
         **kwargs

--- a/bazel_integration_test/internal/default_test_runner.sh
+++ b/bazel_integration_test/internal/default_test_runner.sh
@@ -15,7 +15,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-messages_sh_location=cgrindel_bazel_shlib/lib/messages.sh
+messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
 messages_sh="$(rlocation "${messages_sh_location}")" || \
   (echo >&2 "Failed to locate ${messages_sh_location}" && exit 1)
 source "${messages_sh}"

--- a/bazel_integration_test/internal/integration_test_wrapper.sh
+++ b/bazel_integration_test/internal/integration_test_wrapper.sh
@@ -14,7 +14,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-messages_sh_location=cgrindel_bazel_shlib/lib/messages.sh
+messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
 messages_sh="$(rlocation "${messages_sh_location}")" || \
   (echo >&2 "Failed to locate ${messages_sh_location}" && exit 1)
 source "${messages_sh}"

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(
-    "@cgrindel_bazel_doc//bazeldoc:bazeldoc.bzl",
+    "@cgrindel_bazel_starlib//bazeldoc:defs.bzl",
     "doc_for_provs",
     "write_file_list",
     "write_header",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION", "OTHER_BAZEL_VERSIONS")
 load(
     "//bazel_integration_test:bazel_integration_test.bzl",
@@ -66,7 +66,7 @@ sh_binary(
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:assertions",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
     ],
 )
 

--- a/examples/custom_test_runner/WORKSPACE
+++ b/examples/custom_test_runner/WORKSPACE
@@ -11,21 +11,13 @@ load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", 
 
 bazel_integration_test_rules_dependencies()
 
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
-
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
 
-load("@cgrindel_bazel_shlib//:deps.bzl", "shlib_rules_dependencies")
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
-shlib_rules_dependencies()
+bazel_skylib_workspace()
 
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 load("@build_bazel_integration_testing//tools:repositories.bzl", "bazel_binaries")

--- a/examples/simple/BUILD.bazel
+++ b/examples/simple/BUILD.bazel
@@ -1,8 +1,8 @@
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
 )
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg()
 

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -2,28 +2,14 @@ workspace(name = "simple_example")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "cgrindel_rules_bzlformat",
-    sha256 = "b45b392613092b42c4ee94051be104b990e3c8651dea17410dfd63b98957cd57",
-    strip_prefix = "rules_bzlformat-0.1.0",
-    urls = ["https://github.com/cgrindel/rules_bzlformat/archive/v0.1.0.tar.gz"],
+local_repository(
+    name = "cgrindel_bazel_starlib",
+    path = "../../bazel-starlib",
 )
-
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
 
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
-
-load("@cgrindel_rules_updatesrc//updatesrc:deps.bzl", "updatesrc_rules_dependencies")
-
-updatesrc_rules_dependencies()
 
 # Buildifier Dependencies
 

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -2,14 +2,20 @@ workspace(name = "simple_example")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# TODO: FIX ME!
+
 local_repository(
     name = "cgrindel_bazel_starlib",
-    path = "../../bazel-starlib",
+    path = "/Users/chuck/code/cgrindel/bazel-starlib",
 )
 
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 # Buildifier Dependencies
 

--- a/examples/simple/WORKSPACE
+++ b/examples/simple/WORKSPACE
@@ -2,11 +2,13 @@ workspace(name = "simple_example")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# TODO: FIX ME!
-
-local_repository(
+http_archive(
     name = "cgrindel_bazel_starlib",
-    path = "/Users/chuck/code/cgrindel/bazel-starlib",
+    sha256 = "238c05abf31447b93bd15b616c7413c4c719ee7b5e81c1489ca20f02ce628489",
+    strip_prefix = "bazel-starlib-0.2.0",
+    urls = [
+        "http://github.com/cgrindel/bazel-starlib/archive/v0.2.0.tar.gz",
+    ],
 )
 
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")

--- a/examples/simple/mockascript/BUILD.bazel
+++ b/examples/simple/mockascript/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzl_library(
     name = "deps",
@@ -11,7 +11,7 @@ bzl_library(
     srcs = ["mockascript.bzl"],
     deps = [
         "//mockascript/internal:mockascript_library",
-        "@cgrindel_rules_bzlformat//bzlformat",
+        "@cgrindel_bazel_starlib//bzlformat",
     ],
 )
 

--- a/examples/simple/mockascript/BUILD.bazel
+++ b/examples/simple/mockascript/BUILD.bazel
@@ -11,7 +11,6 @@ bzl_library(
     srcs = ["mockascript.bzl"],
     deps = [
         "//mockascript/internal:mockascript_library",
-        "@cgrindel_bazel_starlib//bzlformat",
     ],
 )
 

--- a/examples/simple/mockascript/internal/BUILD.bazel
+++ b/examples/simple/mockascript/internal/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 package(default_visibility = ["//mockascript:__subpackages__"])
 

--- a/examples/simple/tests/BUILD.bazel
+++ b/examples/simple/tests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":mockascript_tests.bzl", "mockascript_test_suite")
 
 bzlformat_pkg(name = "bzlformat")

--- a/examples/use_create_scratch_dir_test.sh
+++ b/examples/use_create_scratch_dir_test.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-assertions_sh_location=cgrindel_bazel_shlib/lib/assertions.sh
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
 assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load(":integration_test_utils_tests.bzl", "integration_test_utils_test_suite")
 
 bzlformat_pkg(name = "bzlformat")

--- a/tests/tools_tests/BUILD.bazel
+++ b/tests/tools_tests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -19,7 +19,7 @@ sh_test(
     deps = [
         ":setup_test_workspace",
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:assertions",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
     ],
 )
 
@@ -32,7 +32,7 @@ sh_test(
     deps = [
         ":setup_test_workspace",
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:assertions",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
     ],
 )
 
@@ -44,6 +44,6 @@ sh_test(
     ],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:assertions",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
     ],
 )

--- a/tests/tools_tests/create_scratch_dir_test.sh
+++ b/tests/tools_tests/create_scratch_dir_test.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-assertions_lib="$(rlocation cgrindel_bazel_shlib/lib/assertions.sh)"
+assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
 create_scratch_dir_sh_location=cgrindel_rules_bazel_integration_test/tools/create_scratch_dir.sh

--- a/tests/tools_tests/find_child_workspace_packages_test.sh
+++ b/tests/tools_tests/find_child_workspace_packages_test.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-assertions_lib="$(rlocation cgrindel_bazel_shlib/lib/assertions.sh)"
+assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
 find_bin="$(rlocation cgrindel_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"

--- a/tests/tools_tests/update_deleted_packages_test.sh
+++ b/tests/tools_tests/update_deleted_packages_test.sh
@@ -11,7 +11,7 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-assertions_lib="$(rlocation cgrindel_bazel_shlib/lib/assertions.sh)"
+assertions_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/assertions.sh)"
 source "${assertions_lib}"
 
 update_bin="$(rlocation cgrindel_rules_bazel_integration_test/tools/update_deleted_packages.sh)"

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -16,8 +16,8 @@ sh_binary(
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:arrays",
-        "@cgrindel_bazel_shlib//lib:files",
+        "@cgrindel_bazel_starlib//shlib/lib:arrays",
+        "@cgrindel_bazel_starlib//shlib/lib:files",
     ],
 )
 
@@ -30,10 +30,10 @@ sh_binary(
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:arrays",
-        "@cgrindel_bazel_shlib//lib:files",
-        "@cgrindel_bazel_shlib//lib:messages",
-        "@cgrindel_bazel_shlib//lib:paths",
+        "@cgrindel_bazel_starlib//shlib/lib:arrays",
+        "@cgrindel_bazel_starlib//shlib/lib:files",
+        "@cgrindel_bazel_starlib//shlib/lib:messages",
+        "@cgrindel_bazel_starlib//shlib/lib:paths",
     ],
 )
 
@@ -43,7 +43,7 @@ sh_binary(
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_shlib//lib:messages",
-        "@cgrindel_bazel_shlib//lib:paths",
+        "@cgrindel_bazel_starlib//shlib/lib:messages",
+        "@cgrindel_bazel_starlib//shlib/lib:paths",
     ],
 )

--- a/tools/create_scratch_dir.sh
+++ b/tools/create_scratch_dir.sh
@@ -13,12 +13,12 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 
 # MARK - Source Libraries
 
-messages_sh_location=cgrindel_bazel_shlib/lib/messages.sh
+messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
 messages_sh="$(rlocation "${messages_sh_location}")" || \
   (echo >&2 "Failed to locate ${messages_sh_location}" && exit 1)
 source "${messages_sh}"
 
-paths_sh_location=cgrindel_bazel_shlib/lib/paths.sh
+paths_sh_location=cgrindel_bazel_starlib/shlib/lib/paths.sh
 paths_sh="$(rlocation "${paths_sh_location}")" || \
   (echo >&2 "Failed to locate ${paths_sh_location}" && exit 1)
 source "${paths_sh}"

--- a/tools/find_child_workspace_packages.sh
+++ b/tools/find_child_workspace_packages.sh
@@ -18,10 +18,10 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
   { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-arrays_lib="$(rlocation cgrindel_bazel_shlib/lib/arrays.sh)"
+arrays_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/arrays.sh)"
 source "${arrays_lib}"
 
-files_lib="$(rlocation cgrindel_bazel_shlib/lib/files.sh)"
+files_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/files.sh)"
 source "${files_lib}"
 
 # MARK - Functions

--- a/tools/update_deleted_packages.sh
+++ b/tools/update_deleted_packages.sh
@@ -28,18 +28,18 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 
 find_pkgs_script="$(rlocation cgrindel_rules_bazel_integration_test/tools/find_child_workspace_packages.sh)"
 
-messages_sh_location=cgrindel_bazel_shlib/lib/messages.sh
+messages_sh_location=cgrindel_bazel_starlib/shlib/lib/messages.sh
 messages_sh="$(rlocation "${messages_sh_location}")" || \
   (echo >&2 "Failed to locate ${messages_sh_location}" && exit 1)
 source "${messages_sh}"
 
-arrays_lib="$(rlocation cgrindel_bazel_shlib/lib/arrays.sh)"
+arrays_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/arrays.sh)"
 source "${arrays_lib}"
 
-files_lib="$(rlocation cgrindel_bazel_shlib/lib/files.sh)"
+files_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/files.sh)"
 source "${files_lib}"
 
-paths_lib="$(rlocation cgrindel_bazel_shlib/lib/paths.sh)"
+paths_lib="$(rlocation cgrindel_bazel_starlib/shlib/lib/paths.sh)"
 source "${paths_lib}"
 
 # MARK - Main


### PR DESCRIPTION
Related to cgrindel/bazel-starlib#44.