### PR TITLE
Allow `env_inherit` values to be added or overridden.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,8 +3,8 @@
 # This lets us glob() up all the files inside the examples to make them inputs to tests
 # (Note, we cannot use `common --deleted_packages` because the bazel version command doesn't support it)
 # To update these lines, run tools/update_deleted_packages.sh
-build --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests
-query --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests
+build --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
+query --deleted_packages=examples/custom_test_runner,examples/custom_test_runner/Sources/CustomTestRunner,examples/custom_test_runner/Tests/CustomTestRunnerTests,examples/custom_test_runner/integration_tests,examples/custom_test_runner/integration_tests/workspace,examples/simple,examples/simple/mockascript,examples/simple/mockascript/private,examples/simple/tests,tests/params_tests/workspace
 
 # Import Shared settings
 import %workspace%/shared.bazelrc

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,6 +22,7 @@ bzlformat_missing_pkgs(
 updatesrc_update_all(
     name = "update_all",
     targets_to_run = [
+        "@cgrindel_rules_bazel_integration_test//tools:update_deleted_packages",
         "//doc:update",
         ":bzlformat_missing_pkgs_fix",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,6 +55,7 @@ test_suite(
     tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
     tests = [
         "//examples:integration_tests",
+        "//tests/params_tests:integration_tests",
         "//tests/py_tests:integration_tests",
     ],
     visibility = ["//:__subpackages__"],

--- a/doc/rules_and_macros_overview.md
+++ b/doc/rules_and_macros_overview.md
@@ -17,7 +17,7 @@ On this page:
 
 <pre>
 bazel_integration_test(<a href="#bazel_integration_test-name">name</a>, <a href="#bazel_integration_test-test_runner">test_runner</a>, <a href="#bazel_integration_test-bazel_version">bazel_version</a>, <a href="#bazel_integration_test-bazel_binary">bazel_binary</a>, <a href="#bazel_integration_test-workspace_path">workspace_path</a>,
-                       <a href="#bazel_integration_test-workspace_files">workspace_files</a>, <a href="#bazel_integration_test-tags">tags</a>, <a href="#bazel_integration_test-timeout">timeout</a>, <a href="#bazel_integration_test-kwargs">kwargs</a>)
+                       <a href="#bazel_integration_test-workspace_files">workspace_files</a>, <a href="#bazel_integration_test-tags">tags</a>, <a href="#bazel_integration_test-timeout">timeout</a>, <a href="#bazel_integration_test-env_inherit">env_inherit</a>, <a href="#bazel_integration_test-additional_env_inherit">additional_env_inherit</a>, <a href="#bazel_integration_test-kwargs">kwargs</a>)
 </pre>
 
 Macro that defines a set of targets for a single Bazel integration test.
@@ -45,6 +45,8 @@ default test runner is provided by the `default_test_runner` macro.
 | <a id="bazel_integration_test-workspace_files"></a>workspace_files |  Optional. A <code>list</code> of files for the child workspace. If not specified, then it is derived from the <code>workspace_path</code>.   |  <code>None</code> |
 | <a id="bazel_integration_test-tags"></a>tags |  The Bazel tags to apply to the test declaration.   |  <code>["exclusive", "manual"]</code> |
 | <a id="bazel_integration_test-timeout"></a>timeout |  A valid Bazel timeout value. https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner   |  <code>"long"</code> |
+| <a id="bazel_integration_test-env_inherit"></a>env_inherit |  Optional. Override the env_inherit values passed to the test. Only do this if you understand what needs to be passed along. Most folks will want to use <code>additional_env_inherit</code> to pass additional env_inherit values.   |  <code>["SUDO_ASKPASS", "HOME"]</code> |
+| <a id="bazel_integration_test-additional_env_inherit"></a>additional_env_inherit |  Optional. Specify additional <code>env_inherit</code> values that should be passed to the test.   |  <code>[]</code> |
 | <a id="bazel_integration_test-kwargs"></a>kwargs |  additional attributes like timeout and visibility   |  none |
 
 
@@ -54,7 +56,7 @@ default test runner is provided by the `default_test_runner` macro.
 
 <pre>
 bazel_integration_tests(<a href="#bazel_integration_tests-name">name</a>, <a href="#bazel_integration_tests-test_runner">test_runner</a>, <a href="#bazel_integration_tests-bazel_versions">bazel_versions</a>, <a href="#bazel_integration_tests-workspace_path">workspace_path</a>, <a href="#bazel_integration_tests-workspace_files">workspace_files</a>, <a href="#bazel_integration_tests-tags">tags</a>,
-                        <a href="#bazel_integration_tests-timeout">timeout</a>, <a href="#bazel_integration_tests-kwargs">kwargs</a>)
+                        <a href="#bazel_integration_tests-timeout">timeout</a>, <a href="#bazel_integration_tests-env_inherit">env_inherit</a>, <a href="#bazel_integration_tests-additional_env_inherit">additional_env_inherit</a>, <a href="#bazel_integration_tests-kwargs">kwargs</a>)
 </pre>
 
 Macro that defines a set Bazel integration tests each executed with a different version of Bazel.
@@ -71,6 +73,8 @@ Macro that defines a set Bazel integration tests each executed with a different 
 | <a id="bazel_integration_tests-workspace_files"></a>workspace_files |  Optional. A <code>list</code> of files for the child workspace. If not specified, then it is derived from the <code>workspace_path</code>.   |  <code>None</code> |
 | <a id="bazel_integration_tests-tags"></a>tags |  The Bazel tags to apply to the test declaration.   |  <code>["exclusive", "manual"]</code> |
 | <a id="bazel_integration_tests-timeout"></a>timeout |  A valid Bazel timeout value. https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner   |  <code>"long"</code> |
+| <a id="bazel_integration_tests-env_inherit"></a>env_inherit |  Optional. Override the env_inherit values passed to the test. Only do this if you understand what needs to be passed along. Most folks will want to use <code>additional_env_inherit</code> to pass additional env_inherit values.   |  <code>["SUDO_ASKPASS", "HOME"]</code> |
+| <a id="bazel_integration_tests-additional_env_inherit"></a>additional_env_inherit |  Optional. Specify additional <code>env_inherit</code> values that should be passed to the test.   |  <code>[]</code> |
 | <a id="bazel_integration_tests-kwargs"></a>kwargs |  additional attributes like timeout and visibility   |  none |
 
 

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -12,14 +12,31 @@ default_test_runner(
     name = "test_runner",
 )
 
-# If you only want to execute against a single version of Bazel, use
-# bazel_integration_test.
+# MARK: - Default Env Inherit
+
 bazel_integration_test(
-    name = "no_additional_env_inherit_test",
+    name = "default_env_inherit_int_test",
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":test_runner",
     workspace_path = "workspace",
 )
 
+genquery(
+    name = "default_env_inherit_query",
+    testonly = True,
+    expression = """\
+//tests/params_tests:default_env_inherit_int_test\
+""",
+    opts = ["--output=build"],
+    scope = ["//tests/params_tests:default_env_inherit_int_test"],
+)
+
 # TODO: Add additional bazel integration test targets with env_inherit.
+# bazel_integration_test(
+#     name = "override_env_inherit_test",
+#     bazel_version = CURRENT_BAZEL_VERSION,
+#     test_runner = ":test_runner",
+#     workspace_path = "workspace",
+# )
+
 # TODO: Add additional bazel integration test targets with additional_env_inherit.

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -5,6 +5,7 @@ load(
     "bazel_integration_test",
     "default_test_runner",
 )
+load(":env_inherit_attr_test.bzl", "env_inherit_attr_test")
 
 bzlformat_pkg(name = "bzlformat")
 
@@ -21,32 +22,41 @@ bazel_integration_test(
     workspace_path = "workspace",
 )
 
-genquery(
-    name = "default_env_inherit_query",
-    testonly = True,
-    expression = "//tests/params_tests:default_env_inherit_int_test",
-    # opts = ["--output=build"],
-    opts = [
-        "--output=xml",
-        "--xml:default_values",
-    ],
-    scope = ["//tests/params_tests:default_env_inherit_int_test"],
-)
-
-sh_test(
-    name = "default_env_inherit_attr_test",
-    srcs = ["env_inherit_attr_test.sh"],
-    args = [
-        "$(location :default_env_inherit_query)",
+env_inherit_attr_test(
+    name = "default_env_inherit_values_test",
+    expected_values = [
         "HOME",
         "SUDO_ASKPASS",
     ],
-    data = [":default_env_inherit_query"],
-    deps = [
-        "@bazel_tools//tools/bash/runfiles",
-        "@cgrindel_bazel_starlib//shlib/lib:assertions",
-    ],
+    integration_test = "//tests/params_tests:default_env_inherit_int_test",
 )
+
+# genquery(
+#     name = "default_env_inherit_query",
+#     testonly = True,
+#     expression = "//tests/params_tests:default_env_inherit_int_test",
+#     # opts = ["--output=build"],
+#     opts = [
+#         "--output=xml",
+#         "--xml:default_values",
+#     ],
+#     scope = ["//tests/params_tests:default_env_inherit_int_test"],
+# )
+
+# sh_test(
+#     name = "default_env_inherit_attr_test",
+#     srcs = ["env_inherit_attr_test.sh"],
+#     args = [
+#         "$(location :default_env_inherit_query)",
+#         "HOME",
+#         "SUDO_ASKPASS",
+#     ],
+#     data = [":default_env_inherit_query"],
+#     deps = [
+#         "@bazel_tools//tools/bash/runfiles",
+#         "@cgrindel_bazel_starlib//shlib/lib:assertions",
+#     ],
+# )
 
 # TODO: Add additional bazel integration test targets with env_inherit.
 # bazel_integration_test(

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -25,10 +25,11 @@ genquery(
     name = "default_env_inherit_query",
     testonly = True,
     expression = "//tests/params_tests:default_env_inherit_int_test",
-    # expression = """\
-    # attr("env_inherit", "\\[\\]", //tests/params_tests:default_env_inherit_int_test)\
-    # """,
-    opts = ["--output=build"],
+    # opts = ["--output=build"],
+    opts = [
+        "--output=xml",
+        "--xml:default_values",
+    ],
     scope = ["//tests/params_tests:default_env_inherit_int_test"],
 )
 
@@ -37,7 +38,8 @@ sh_test(
     srcs = ["env_inherit_attr_test.sh"],
     args = [
         "$(location :default_env_inherit_query)",
-        "FOO",
+        "HOME",
+        "SUDO_ASKPASS",
     ],
     data = [":default_env_inherit_query"],
     deps = [

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -20,3 +20,6 @@ bazel_integration_test(
     test_runner = ":test_runner",
     workspace_path = "workspace",
 )
+
+# TODO: Add additional bazel integration test targets with env_inherit.
+# TODO: Add additional bazel integration test targets with additional_env_inherit.

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -24,11 +24,26 @@ bazel_integration_test(
 genquery(
     name = "default_env_inherit_query",
     testonly = True,
-    expression = """\
-//tests/params_tests:default_env_inherit_int_test\
-""",
+    expression = "//tests/params_tests:default_env_inherit_int_test",
+    # expression = """\
+    # attr("env_inherit", "\\[\\]", //tests/params_tests:default_env_inherit_int_test)\
+    # """,
     opts = ["--output=build"],
     scope = ["//tests/params_tests:default_env_inherit_int_test"],
+)
+
+sh_test(
+    name = "default_env_inherit_attr_test",
+    srcs = ["env_inherit_attr_test.sh"],
+    args = [
+        "$(location :default_env_inherit_query)",
+        "FOO",
+    ],
+    data = [":default_env_inherit_query"],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
+    ],
 )
 
 # TODO: Add additional bazel integration test targets with env_inherit.

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load("//:bazel_versions.bzl", "CURRENT_BAZEL_VERSION")
+load(
+    "//bazel_integration_test:defs.bzl",
+    "bazel_integration_test",
+    "default_test_runner",
+)
+
+bzlformat_pkg(name = "bzlformat")
+
+default_test_runner(
+    name = "test_runner",
+)
+
+# If you only want to execute against a single version of Bazel, use
+# bazel_integration_test.
+bazel_integration_test(
+    name = "no_additional_env_inherit_test",
+    bazel_version = CURRENT_BAZEL_VERSION,
+    test_runner = ":test_runner",
+    workspace_path = "workspace",
+)

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -4,6 +4,7 @@ load(
     "//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
     "default_test_runner",
+    "integration_test_utils",
 )
 load(":env_inherit_attr_test.bzl", "env_inherit_attr_test")
 
@@ -75,4 +76,19 @@ env_inherit_attr_test(
         "CHICKEN",
     ],
     integration_test = "//tests/params_tests:additional_env_inherit_int_test",
+)
+
+# MARK: - Test Suite
+
+test_suite(
+    name = "integration_tests",
+    tags = integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
+    # These integration tests do not really test any functionality. Instead, we
+    # are testing the passthrough of certain attributes. So, to save some time
+    # and energy, we only execute one fo the tests, just to be sure that it is
+    # valid/works.
+    tests = [
+        ":default_env_inherit_int_test",
+    ],
+    visibility = ["//:__subpackages__"],
 )

--- a/tests/params_tests/BUILD.bazel
+++ b/tests/params_tests/BUILD.bazel
@@ -13,7 +13,7 @@ default_test_runner(
     name = "test_runner",
 )
 
-# MARK: - Default Env Inherit
+# MARK: - Default env_inherit
 
 bazel_integration_test(
     name = "default_env_inherit_int_test",
@@ -31,39 +31,48 @@ env_inherit_attr_test(
     integration_test = "//tests/params_tests:default_env_inherit_int_test",
 )
 
-# genquery(
-#     name = "default_env_inherit_query",
-#     testonly = True,
-#     expression = "//tests/params_tests:default_env_inherit_int_test",
-#     # opts = ["--output=build"],
-#     opts = [
-#         "--output=xml",
-#         "--xml:default_values",
-#     ],
-#     scope = ["//tests/params_tests:default_env_inherit_int_test"],
-# )
+# MARK: - Override env_inherit
 
-# sh_test(
-#     name = "default_env_inherit_attr_test",
-#     srcs = ["env_inherit_attr_test.sh"],
-#     args = [
-#         "$(location :default_env_inherit_query)",
-#         "HOME",
-#         "SUDO_ASKPASS",
-#     ],
-#     data = [":default_env_inherit_query"],
-#     deps = [
-#         "@bazel_tools//tools/bash/runfiles",
-#         "@cgrindel_bazel_starlib//shlib/lib:assertions",
-#     ],
-# )
+bazel_integration_test(
+    name = "override_env_inherit_int_test",
+    bazel_version = CURRENT_BAZEL_VERSION,
+    env_inherit = [
+        "HOME",
+        "SUDO_ASKPASS",
+        "CHICKEN",
+    ],
+    test_runner = ":test_runner",
+    workspace_path = "workspace",
+)
 
-# TODO: Add additional bazel integration test targets with env_inherit.
-# bazel_integration_test(
-#     name = "override_env_inherit_test",
-#     bazel_version = CURRENT_BAZEL_VERSION,
-#     test_runner = ":test_runner",
-#     workspace_path = "workspace",
-# )
+env_inherit_attr_test(
+    name = "override_env_inherit_values_test",
+    expected_values = [
+        "HOME",
+        "SUDO_ASKPASS",
+        "CHICKEN",
+    ],
+    integration_test = "//tests/params_tests:override_env_inherit_int_test",
+)
 
-# TODO: Add additional bazel integration test targets with additional_env_inherit.
+# MARK: - Add env_inherit Values
+
+bazel_integration_test(
+    name = "additional_env_inherit_int_test",
+    additional_env_inherit = [
+        "CHICKEN",
+    ],
+    bazel_version = CURRENT_BAZEL_VERSION,
+    test_runner = ":test_runner",
+    workspace_path = "workspace",
+)
+
+env_inherit_attr_test(
+    name = "additional_env_inherit_values_test",
+    expected_values = [
+        "HOME",
+        "SUDO_ASKPASS",
+        "CHICKEN",
+    ],
+    integration_test = "//tests/params_tests:additional_env_inherit_int_test",
+)

--- a/tests/params_tests/env_inherit_attr_test.bzl
+++ b/tests/params_tests/env_inherit_attr_test.bzl
@@ -1,0 +1,34 @@
+"""Macro for asserting the existence of `env_inherit` values."""
+
+def env_inherit_attr_test(name, integration_test, expected_values):
+    """Test for the existence of the specified values for a test target's `env_inherit` attribute.
+
+    Args:
+        name: The name of the test.
+        integration_test: The test target to check.
+        expected_values: A `list` of `string` values expected in `env_inherit`.
+    """
+    query_name = name + "_query"
+    native.genquery(
+        name = query_name,
+        testonly = True,
+        expression = integration_test,
+        opts = [
+            "--output=xml",
+            "--xml:default_values",
+        ],
+        scope = [integration_test],
+    )
+
+    native.sh_test(
+        name = name,
+        srcs = ["env_inherit_attr_test.sh"],
+        args = [
+            "$(location {query_name})".format(query_name = query_name),
+        ] + expected_values,
+        data = [query_name],
+        deps = [
+            "@bazel_tools//tools/bash/runfiles",
+            "@cgrindel_bazel_starlib//shlib/lib:assertions",
+        ],
+    )

--- a/tests/params_tests/env_inherit_attr_test.bzl
+++ b/tests/params_tests/env_inherit_attr_test.bzl
@@ -30,5 +30,6 @@ def env_inherit_attr_test(name, integration_test, expected_values):
         deps = [
             "@bazel_tools//tools/bash/runfiles",
             "@cgrindel_bazel_starlib//shlib/lib:assertions",
+            "@cgrindel_bazel_starlib//shlib/lib:env",
         ],
     )

--- a/tests/params_tests/env_inherit_attr_test.sh
+++ b/tests/params_tests/env_inherit_attr_test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# MARK - Locate Deps
+
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+source "${assertions_sh}"
+
+
+# MARK - Process Args
+
+query_output="${1}"
+shift 1
+
+expected_env_inherit_values=()
+while (("$#")); do
+  expected_env_inherit_values+=( "${1}" )
+  shift 1
+done
+
+[[ ${#expected_env_inherit_values} == 0 ]] && fail "No expected values were provided."
+
+
+# MARK - Test
+
+
+
+fail "IMPLEMENT ME!"

--- a/tests/params_tests/env_inherit_attr_test.sh
+++ b/tests/params_tests/env_inherit_attr_test.sh
@@ -33,8 +33,20 @@ done
 [[ ${#expected_env_inherit_values} == 0 ]] && fail "No expected values were provided."
 
 
+# MARK - Assertion Functions
+
+assert_env_inherit_value() {
+  local attr="${1}"
+  local xpath='//rule[@class="sh_test"]/list[@name="env_inherit"]/string[@value="'"${attr}"'"]'
+  if xmllint --xpath "${xpath}" "${query_output}" &>/dev/null; then 
+    return 0
+  else
+    fail "Did not find env_inherit value. expected: ${attr}"
+  fi
+}
+
 # MARK - Test
 
-
-
-fail "IMPLEMENT ME!"
+for value in "${expected_env_inherit_values[@]}" ; do
+  assert_env_inherit_value "${value}"
+done

--- a/tests/params_tests/env_inherit_attr_test.sh
+++ b/tests/params_tests/env_inherit_attr_test.sh
@@ -18,6 +18,12 @@ assertions_sh="$(rlocation "${assertions_sh_location}")" || \
   (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
 source "${assertions_sh}"
 
+env_sh_location=cgrindel_bazel_starlib/shlib/lib/env.sh
+env_sh="$(rlocation "${env_sh_location}")" || \
+  (echo >&2 "Failed to locate ${env_sh_location}" && exit 1)
+source "${env_sh}"
+
+is_installed xmllint || fail "The env_inherit_attr_test requires xmllint to be installed."
 
 # MARK - Process Args
 

--- a/tests/params_tests/workspace/BUILD.bazel
+++ b/tests/params_tests/workspace/BUILD.bazel
@@ -1,0 +1,4 @@
+sh_test(
+    name = "noop_test",
+    srcs = ["noop_test.sh"],
+)

--- a/tests/params_tests/workspace/WORKSPACE
+++ b/tests/params_tests/workspace/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "params_test_workspace")

--- a/tests/params_tests/workspace/noop_test.sh
+++ b/tests/params_tests/workspace/noop_test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Hello"


### PR DESCRIPTION
- Added `env_inherit` to `bazel_integration_test` and `bazel_integration_tests` to allow the `env_inherit` values to be overridden.
- Added `additional_env_inherit` to `bazel_integration_test` and `bazel_integration_tests` to allow additional `env_inherit` values to be specified.